### PR TITLE
Removing import of Default.props file

### DIFF
--- a/cpython/Tools/pyuwp/pyuwpsdk/DesignTime/CommonConfiguration/Neutral/CPython.props
+++ b/cpython/Tools/pyuwp/pyuwpsdk/DesignTime/CommonConfiguration/Neutral/CPython.props
@@ -6,8 +6,6 @@
     <AppxPackage>true</AppxPackage>
     <WindowsAppContainer>true</WindowsAppContainer>
     <IncludeCustomOutputGroupForPackaging>true</IncludeCustomOutputGroupForPackaging>
-    <_ApplicationTypeDefaultPropsPath>$(VCTargetsPath)\Application Type\Windows Store\Default.props</_ApplicationTypeDefaultPropsPath>
-    <_ApplicationTypeRevisionDefaultPropsPath Condition="'$(ApplicationTypeRevision)' != ''">$(VCTargetsPath)\Application Type\Windows Store\$(ApplicationTypeRevision)\Default.props</_ApplicationTypeRevisionDefaultPropsPath>
   </PropertyGroup>
     
   <PropertyGroup>

--- a/cpython/Tools/pyuwp/pyuwpsdk/DesignTime/CommonConfiguration/Neutral/CPython.targets
+++ b/cpython/Tools/pyuwp/pyuwpsdk/DesignTime/CommonConfiguration/Neutral/CPython.targets
@@ -11,8 +11,6 @@
   
   <Import Project="$(MSBuildThisFileDirectory)CPython.props" />
 
-  <Import Condition="'$(_ApplicationTypeDefaultPropsPath)' != '' and Exists('$(_ApplicationTypeDefaultPropsPath)')" Project="$(_ApplicationTypeDefaultPropsPath)" />
-  <Import Condition="'$(_ApplicationTypeRevisionDefaultPropsPath)' != '' and Exists('$(_ApplicationTypeRevisionDefaultPropsPath)')" Project="$(_ApplicationTypeRevisionDefaultPropsPath)" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 
   <ItemGroup>


### PR DESCRIPTION
This change is related to https://github.com/Microsoft/PTVS/pull/530.
Removing this import is required since it's not necessary and it
was setting the target sdk version to "7.0"
