### PR TITLE
Add SDK reference so VCLibs dependency is added to Python UWP manifest

### DIFF
--- a/cpython/Tools/pyuwp/pyuwpsdk/DesignTime/CommonConfiguration/Neutral/CPython.targets
+++ b/cpython/Tools/pyuwp/pyuwpsdk/DesignTime/CommonConfiguration/Neutral/CPython.targets
@@ -14,6 +14,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 
   <ItemGroup>
+	<SDKReference Include="Microsoft.VCLibs, Version=14.0" />
     <PythonHost Include="$(CPythonSDKPath)\Redist\$(RedistConfiguration)\$(RedistPlatform)\*"/>
     <PythonHost Include="$(CPythonSDKPath)\References\CommonConfiguration\Neutral\**\*" />
   </ItemGroup>


### PR DESCRIPTION
Fixes deploy failure with latest Win 10 tools.
