### PR TITLE
WACK API cleanup

### DIFF
--- a/cpython/Modules/_ctypes/callproc.c
+++ b/cpython/Modules/_ctypes/callproc.c
@@ -1252,19 +1252,6 @@ static PyObject *format_error(PyObject *self, PyObject *args)
     return result;
 }
 
-#ifdef MS_UWP
-WINBASEAPI
-_Ret_maybenull_
-HMODULE
-WINAPI
-LoadLibraryExW(
-_In_ LPCWSTR lpLibFileName,
-_Reserved_ HANDLE hFile,
-_In_ DWORD dwFlags
-);
-#define LOAD_PACKAGED_LIBRARY 0x00000004
-#endif
-
 static char load_library_doc[] =
 "LoadLibrary(name) -> handle\n\
 \n\
@@ -1285,7 +1272,7 @@ static PyObject *load_library(PyObject *self, PyObject *args)
         return NULL;
 
 #ifdef MS_UWP
-	hMod = LoadLibraryExW(name, 0, LOAD_PACKAGED_LIBRARY);
+    hMod = LoadPackagedLibrary(name, 0);
 #else
     hMod = LoadLibraryW(name);
 #endif

--- a/cpython/Modules/_ctypes/callproc.c
+++ b/cpython/Modules/_ctypes/callproc.c
@@ -1242,7 +1242,7 @@ static PyObject *format_error(PyObject *self, PyObject *args)
     if (lpMsgBuf) {
         result = PyUnicode_FromWideChar(lpMsgBuf, wcslen(lpMsgBuf));
 #ifdef MS_UWP
-		HeapFree(GetProcessHeap(), 0, lpMsgBuf);
+        HeapFree(GetProcessHeap(), 0, lpMsgBuf);
 #else
         LocalFree(lpMsgBuf);
 #endif

--- a/cpython/PC/clinic/msvcrtmodule.c.h
+++ b/cpython/PC/clinic/msvcrtmodule.c.h
@@ -165,6 +165,8 @@ exit:
     return return_value;
 }
 
+#if !defined(MS_UWP)
+
 PyDoc_STRVAR(msvcrt_kbhit__doc__,
 "kbhit($module, /)\n"
 "--\n"
@@ -401,6 +403,8 @@ msvcrt_ungetwch(PyModuleDef *module, PyObject *arg)
 exit:
     return return_value;
 }
+
+#endif /* defined(MS_UWP) */
 
 #if defined(_DEBUG)
 

--- a/cpython/PC/msvcrtmodule.c
+++ b/cpython/PC/msvcrtmodule.c
@@ -206,6 +206,8 @@ msvcrt_get_osfhandle_impl(PyModuleDef *module, int fd)
     return handle;
 }
 
+#if !defined(MS_UWP)
+
 /* Console I/O */
 /*[clinic input]
 msvcrt.kbhit -> long
@@ -236,19 +238,12 @@ static int
 msvcrt_getch_impl(PyModuleDef *module)
 /*[clinic end generated code: output=199e3d89f49c166a input=37a40cf0ed0d1153]*/
 {
-#ifndef MS_UWP
     int ch;
-#endif
 
-#ifdef MS_UWP
-    PyErr_SetString(PyExc_NotImplementedError, "Not supported in UWP Apps");
-    return NULL;
-#else
     Py_BEGIN_ALLOW_THREADS
     ch = _getch();
     Py_END_ALLOW_THREADS
     return ch;
-#endif
 }
 
 /*[clinic input]
@@ -279,19 +274,12 @@ static int
 msvcrt_getche_impl(PyModuleDef *module)
 /*[clinic end generated code: output=8aa369be6550068e input=43311ade9ed4a9c0]*/
 {
-#ifndef MS_UWP
     int ch;
-#endif
 
-#ifdef MS_UWP
-    PyErr_SetString(PyExc_NotImplementedError, "Not supported in UWP Apps");
-    return NULL;
-#else
     Py_BEGIN_ALLOW_THREADS
     ch = _getche();
     Py_END_ALLOW_THREADS
     return ch;
-#endif
 }
 
 /*[clinic input]
@@ -364,15 +352,9 @@ static PyObject *
 msvcrt_ungetch_impl(PyModuleDef *module, char char_value)
 /*[clinic end generated code: output=19a4cd3249709ec9 input=22f07ee9001bbf0f]*/
 {
-
-#ifdef MS_UWP
-    PyErr_SetString(PyExc_NotImplementedError, "Not supported in UWP Apps");
-    return NULL;
-#else
     if (_ungetch(char_value) == EOF)
         return PyErr_SetFromErrno(PyExc_IOError);
     Py_RETURN_NONE;
-#endif
 }
 
 /*[clinic input]
@@ -392,6 +374,8 @@ msvcrt_ungetwch_impl(PyModuleDef *module, int unicode_char)
         return PyErr_SetFromErrno(PyExc_IOError);
     Py_RETURN_NONE;
 }
+
+#endif /* defined(MS_UWP) */
 
 #ifdef _DEBUG
 /*[clinic input]
@@ -470,7 +454,7 @@ msvcrt_SetErrorMode_impl(PyModuleDef *module, unsigned int mode)
 /*[clinic end generated code: output=544c60b085be79c6 input=d8b167258d32d907]*/
 {
 #ifndef MS_UWP
-	unsigned int res;
+    unsigned int res;
 #endif
 
 #ifdef MS_UWP
@@ -503,12 +487,11 @@ static struct PyMethodDef msvcrt_functions[] = {
     MSVCRT_CRTSETREPORTFILE_METHODDEF
     MSVCRT_CRTSETREPORTMODE_METHODDEF
     MSVCRT_SET_ERROR_MODE_METHODDEF
-#endif /* !MS_UWP */
     MSVCRT_GETWCH_METHODDEF
     MSVCRT_GETWCHE_METHODDEF
     MSVCRT_PUTWCH_METHODDEF
     MSVCRT_UNGETWCH_METHODDEF
-
+#endif /* !MS_UWP */
     {NULL,                      NULL}
 };
 

--- a/cpython/PCbuild/uwp.props
+++ b/cpython/PCbuild/uwp.props
@@ -18,6 +18,7 @@
     </Link>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/APPCONTAINER %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/cpython/Python/errors.c
+++ b/cpython/Python/errors.c
@@ -493,7 +493,11 @@ PyErr_SetFromErrnoWithFilenameObjects(PyObject *exc, PyObject *filenameObject, P
                 MAKELANGID(LANG_NEUTRAL,
                            SUBLANG_DEFAULT),
                            /* Default language */
+#ifndef MS_UWP
                 (LPWSTR) &s_buf,
+#else
+                s_buf,
+#endif
                 s_buf_len,              /* size not used */
                 NULL);                  /* no args */
             if (len==0) {
@@ -590,7 +594,7 @@ PyObject *PyErr_SetExcFromWindowsErrWithFilenameObjects(
     PyObject *filenameObject2)
 {
     int len;
-#ifdef MS_UWP
+#ifndef MS_UWP
     const int s_buf_len = 0;
     WCHAR *s_buf = NULL; /* Free via LocalFree */
 #else
@@ -613,7 +617,11 @@ PyObject *PyErr_SetExcFromWindowsErrWithFilenameObjects(
         err,
         MAKELANGID(LANG_NEUTRAL,
         SUBLANG_DEFAULT), /* Default language */
+#ifndef MS_UWP
         (LPWSTR) &s_buf,
+#else
+        s_buf,
+#endif
         s_buf_len,
         NULL);          /* no args */
     if (len==0) {


### PR DESCRIPTION
- Added linker option /APPCONTAINER
- Removed the following non-UWP APIs:
  - _getwch()
  - _getwche()
  - _putwch()
  - _ungetwch()
  - LoadLibraryExW()
- Fixed previously incorrect port of FORMAT_MESSAGE_ALLOCATE_BUFFER
