### PR TITLE
Update get_externals.bat to use 'git' instead of 'svn' to sync code from

### DIFF
--- a/cpython/PCbuild/get_externals.bat
+++ b/cpython/PCbuild/get_externals.bat
@@ -6,7 +6,7 @@ if not exist "%~dp0..\externals" mkdir "%~dp0..\externals"
 pushd "%~dp0..\externals"
 
 if "%SVNROOT%"=="" set SVNROOT=http://svn.python.org/projects/external/
-if "%MSSVNROOT%"=="" set MSSVNROOT=https://github.com/Microsoft/openssl/branches/OpenSSL_1_0_2_WinRT-stable/
+if "%MSOPENSSLUWP%"=="" set MSOPENSSLUWP=https://github.com/Microsoft/openssl
 
 rem Optionally clean up first.  Be warned that this can be very destructive!
 if not "%1"=="" (
@@ -70,8 +70,14 @@ for %%e in (
     )
 )
 
-echo.Fetching %MSSVNROOT%...
-svn export %MSSVNROOT% openssl-uwp
+if not exist openssl-uwp (
+    echo.Fetching %MSOPENSSLUWP%...
+    git clone %MSOPENSSLUWP% openssl-uwp
+)
+pushd openssl-uwp
+git checkout OpenSSL_1_0_2_WinRT-stable
+git pull
+popd
 
 goto end
 


### PR DESCRIPTION
"svn export <path to openssl-uwp>" is failing with a server timeout.  Thus, update get_externals.bat to use 'git' instead of 'svn' to sync code from openssl-uwp.  
