### PR TITLE
Update various build files to work with VS2017RC

### DIFF
--- a/cpython/PCbuild/openssl.props
+++ b/cpython/PCbuild/openssl.props
@@ -64,8 +64,8 @@
   </Target>
 
   <Target Name="BuildNasmFiles" BeforeTargets="PreBuildEvent" DependsOnTargets="PrepareForBuild;FindNasm" Inputs="@(NasmCompile)" Outputs="@(NasmCompile->'$(IntDir)%(Filename).obj')">
-    <Exec Command='setlocal
-set PATH=$(nasmDir);%PATH%
+    <Exec Command='setlocal %0A
+set PATH=$(nasmDir);%PATH% %0A
 $(nasm) -o "$(IntDir)%(NasmCompile.Filename).obj" "%(NasmCompile.FullPath)"' />
     <ItemGroup>
       <Link Include="$(IntDir)%(NasmCompile.Filename).obj" />

--- a/cpython/PCbuild/pyproject.props
+++ b/cpython/PCbuild/pyproject.props
@@ -97,10 +97,10 @@
           Inputs="$(PySourcePath)Include\patchlevel.h"
           Outputs="$(PySourcePath)PC\pythonnt_rc$(PyDebugExt).h">
     <WriteLinesToFile File="$(PySourcePath)PC\pythonnt_rc$(PyDebugExt).h" Overwrite="true" Encoding="ascii"
-                      Lines='/* This file created by python.props /t:GeneratePythonNtRcH */
-#define FIELD3 $(Field3Value)
-#define MS_DLL_ID "$(SysWinVer)"
-#define PYTHON_DLL_NAME "$(PyDllName).dll"
+                      Lines='/* This file created by python.props /t:GeneratePythonNtRcH */ %0a
+#define FIELD3 $(Field3Value) %0a
+#define MS_DLL_ID "$(SysWinVer)" %0a
+#define PYTHON_DLL_NAME "$(PyDllName).dll" %0a
 ' />
     <ItemGroup>
         <FileWrites Include="$(PySourcePath)PC\pythonnt_rc$(PyDebugExt).h" />

--- a/cpython/PCbuild/tcltk.props
+++ b/cpython/PCbuild/tcltk.props
@@ -37,6 +37,7 @@
     <BuildDirTop>Release</BuildDirTop>
     <BuildDirTop Condition="$(Configuration) == 'Debug'">Debug</BuildDirTop>
     <BuildDirTop Condition="$(TclMachine) != 'IX86'">$(BuildDirTop)_$(TclMachine)</BuildDirTop>
+    <BuildDirTop Condition="$(VisualStudioVersion) == '15.0'">$(BuildDirTop)_VC13</BuildDirTop>
     <BuildDirTop Condition="$(VisualStudioVersion) == '14.0'">$(BuildDirTop)_VC13</BuildDirTop>
     <BuildDirTop Condition="$(VisualStudioVersion) == '12.0'">$(BuildDirTop)_VC12</BuildDirTop>
     <BuildDirTop Condition="$(VisualStudioVersion) == '11.0'">$(BuildDirTop)_VC11</BuildDirTop>

--- a/cpython/PCbuild/uwp/_bz2.vcxproj
+++ b/cpython/PCbuild/uwp/_bz2.vcxproj
@@ -37,8 +37,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="..\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/cpython/PCbuild/uwp/_bz2.vcxproj
+++ b/cpython/PCbuild/uwp/_bz2.vcxproj
@@ -32,7 +32,7 @@
     <Keyword>Win32Proj</Keyword>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/PCbuild/uwp/_ctypes.vcxproj
+++ b/cpython/PCbuild/uwp/_ctypes.vcxproj
@@ -36,8 +36,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <GenerateManifest>false</GenerateManifest>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="..\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/cpython/PCbuild/uwp/_ctypes.vcxproj
+++ b/cpython/PCbuild/uwp/_ctypes.vcxproj
@@ -32,7 +32,7 @@
     <Keyword>Win32Proj</Keyword>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <GenerateManifest>false</GenerateManifest>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/PCbuild/uwp/_ctypes_test.vcxproj
+++ b/cpython/PCbuild/uwp/_ctypes_test.vcxproj
@@ -37,8 +37,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="..\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/cpython/PCbuild/uwp/_ctypes_test.vcxproj
+++ b/cpython/PCbuild/uwp/_ctypes_test.vcxproj
@@ -33,7 +33,7 @@
     <SupportPGO>false</SupportPGO>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>

--- a/cpython/PCbuild/uwp/_decimal.vcxproj
+++ b/cpython/PCbuild/uwp/_decimal.vcxproj
@@ -32,7 +32,7 @@
     <Keyword>Win32Proj</Keyword>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/PCbuild/uwp/_elementtree.vcxproj
+++ b/cpython/PCbuild/uwp/_elementtree.vcxproj
@@ -31,7 +31,7 @@
     <RootNamespace>_elementtree</RootNamespace>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/PCbuild/uwp/_elementtree.vcxproj
+++ b/cpython/PCbuild/uwp/_elementtree.vcxproj
@@ -36,8 +36,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="..\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/cpython/PCbuild/uwp/_lzma.vcxproj
+++ b/cpython/PCbuild/uwp/_lzma.vcxproj
@@ -32,7 +32,7 @@
     <Keyword>Win32Proj</Keyword>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/PCbuild/uwp/_socket.vcxproj
+++ b/cpython/PCbuild/uwp/_socket.vcxproj
@@ -37,8 +37,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="..\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/cpython/PCbuild/uwp/_socket.vcxproj
+++ b/cpython/PCbuild/uwp/_socket.vcxproj
@@ -32,7 +32,7 @@
     <Keyword>Win32Proj</Keyword>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/PCbuild/uwp/_ssl.vcxproj
+++ b/cpython/PCbuild/uwp/_ssl.vcxproj
@@ -37,8 +37,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="..\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/cpython/PCbuild/uwp/_ssl.vcxproj
+++ b/cpython/PCbuild/uwp/_ssl.vcxproj
@@ -32,7 +32,7 @@
     <Keyword>Win32Proj</Keyword>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/PCbuild/uwp/_ssl.vcxproj
+++ b/cpython/PCbuild/uwp/_ssl.vcxproj
@@ -72,22 +72,22 @@
       <AdditionalOptions Condition="'$(Configuration)'=='Release'">vccorlib.lib msvcrt.lib vcruntime.lib ucrt.lib /defaultlib:windowsapp.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PreBuildEvent>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">call $(ProjectDir)openssl_uwp_build.cmd "$(openSslDir)" $(Configuration) $(Platform)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">call $(ProjectDir)openssl_uwp_build.cmd "$(openSslDir)" $(Configuration) $(Platform) $(TargetPlatformVersion)</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">call $(ProjectDir)openssl_uwp_build.cmd "$(openSslDir)" $(Configuration) $(Platform)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">call $(ProjectDir)openssl_uwp_build.cmd "$(openSslDir)" $(Configuration) $(Platform) $(TargetPlatformVersion)</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">call $(ProjectDir)openssl_uwp_build.cmd "$(openSslDir)" $(Configuration) $(Platform)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">call $(ProjectDir)openssl_uwp_build.cmd "$(openSslDir)" $(Configuration) $(Platform) $(TargetPlatformVersion)</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">call $(ProjectDir)openssl_uwp_build.cmd "$(openSslDir)" $(Configuration) $(Platform)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">call $(ProjectDir)openssl_uwp_build.cmd "$(openSslDir)" $(Configuration) $(Platform) $(TargetPlatformVersion)</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">call $(ProjectDir)openssl_uwp_build.cmd "$(openSslDir)" $(Configuration) $(Platform)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">call $(ProjectDir)openssl_uwp_build.cmd "$(openSslDir)" $(Configuration) $(Platform) $(TargetPlatformVersion)</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">call $(ProjectDir)openssl_uwp_build.cmd "$(openSslDir)" $(Configuration) $(Platform)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">call $(ProjectDir)openssl_uwp_build.cmd "$(openSslDir)" $(Configuration) $(Platform) $(TargetPlatformVersion)</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/cpython/PCbuild/uwp/_testbuffer.vcxproj
+++ b/cpython/PCbuild/uwp/_testbuffer.vcxproj
@@ -31,7 +31,7 @@
     <RootNamespace>_testbuffer</RootNamespace>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/PCbuild/uwp/_testcapi.vcxproj
+++ b/cpython/PCbuild/uwp/_testcapi.vcxproj
@@ -37,8 +37,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="..\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/cpython/PCbuild/uwp/_testcapi.vcxproj
+++ b/cpython/PCbuild/uwp/_testcapi.vcxproj
@@ -33,7 +33,7 @@
     <SupportPGO>false</SupportPGO>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>

--- a/cpython/PCbuild/uwp/_testimportmultiple.vcxproj
+++ b/cpython/PCbuild/uwp/_testimportmultiple.vcxproj
@@ -31,7 +31,7 @@
     <RootNamespace>_testimportmultiple</RootNamespace>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/PCbuild/uwp/_testimportmultiple.vcxproj
+++ b/cpython/PCbuild/uwp/_testimportmultiple.vcxproj
@@ -36,8 +36,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="..\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/cpython/PCbuild/uwp/_testmultiphase.vcxproj
+++ b/cpython/PCbuild/uwp/_testmultiphase.vcxproj
@@ -36,8 +36,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="..\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/cpython/PCbuild/uwp/_testmultiphase.vcxproj
+++ b/cpython/PCbuild/uwp/_testmultiphase.vcxproj
@@ -31,7 +31,7 @@
     <RootNamespace>_testmultiphase</RootNamespace>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/PCbuild/uwp/openssl_uwp_build.cmd
+++ b/cpython/PCbuild/uwp/openssl_uwp_build.cmd
@@ -1,6 +1,7 @@
 setlocal
 set CONFIGURATION=%2
 set PLATFORM=%3
+if not "%4"=="" set _WKITS10VER=%4
 
 if not exist %1 (
     echo %1 does not exist!

--- a/cpython/PCbuild/uwp/pyexpat.vcxproj
+++ b/cpython/PCbuild/uwp/pyexpat.vcxproj
@@ -37,8 +37,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="..\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -63,7 +63,7 @@
       <PreprocessorDefinitions>PYEXPAT_EXPORTS;HAVE_EXPAT_H;XML_NS;XML_DTD;BYTEORDER=1234;XML_CONTEXT_BYTES=1024;XML_STATIC;HAVE_MEMMOVE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-       <ImageHasSafeExceptionHandlers />
+      <ImageHasSafeExceptionHandlers />
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/cpython/PCbuild/uwp/pyexpat.vcxproj
+++ b/cpython/PCbuild/uwp/pyexpat.vcxproj
@@ -32,7 +32,7 @@
     <RootNamespace>pyexpat</RootNamespace>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/PCbuild/uwp/pythoncore.vcxproj
+++ b/cpython/PCbuild/uwp/pythoncore.vcxproj
@@ -37,8 +37,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>true</GenerateManifest>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/cpython/PCbuild/uwp/pythoncore.vcxproj
+++ b/cpython/PCbuild/uwp/pythoncore.vcxproj
@@ -32,7 +32,7 @@
     <RootNamespace>pythoncore</RootNamespace>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/PCbuild/uwp/select.vcxproj
+++ b/cpython/PCbuild/uwp/select.vcxproj
@@ -30,7 +30,7 @@
     <RootNamespace>select</RootNamespace>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/PCbuild/uwp/select.vcxproj
+++ b/cpython/PCbuild/uwp/select.vcxproj
@@ -36,8 +36,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>
     <ProjectGuid>{A1863EDB-6843-4B69-896B-E9183E94751C}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="..\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/cpython/PCbuild/uwp/unicodedata.vcxproj
+++ b/cpython/PCbuild/uwp/unicodedata.vcxproj
@@ -36,8 +36,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="..\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/cpython/PCbuild/uwp/unicodedata.vcxproj
+++ b/cpython/PCbuild/uwp/unicodedata.vcxproj
@@ -31,7 +31,7 @@
     <RootNamespace>unicodedata</RootNamespace>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/Tools/pyuwp/ptvsdhelper/_ptvsdhelper.vcxproj
+++ b/cpython/Tools/pyuwp/ptvsdhelper/_ptvsdhelper.vcxproj
@@ -32,7 +32,7 @@
     <RootNamespace>pyexpat</RootNamespace>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VCTargetsPath14)' != ''">v141</PlatformToolset>
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/cpython/Tools/pyuwp/ptvsdhelper/_ptvsdhelper.vcxproj
+++ b/cpython/Tools/pyuwp/ptvsdhelper/_ptvsdhelper.vcxproj
@@ -37,8 +37,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateManifest>false</GenerateManifest>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="..\..\..\PCBuild\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/cpython/Tools/pyuwp/pyuwpbackgroundservice/pyuwpbackgroundservice.vcxproj
+++ b/cpython/Tools/pyuwp/pyuwpbackgroundservice/pyuwpbackgroundservice.vcxproj
@@ -41,8 +41,8 @@
     <AppxPackageSigningEnabled>true</AppxPackageSigningEnabled>
     <PackageCertificateKeyFile>pyuwpbackgroundservice_TemporaryKey.pfx</PackageCertificateKeyFile>
     <ContainsStartupTask>true</ContainsStartupTask>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -445,24 +445,20 @@
       <PythonLibFiles Remove="@(ExcludeLibFilters)" />
     </ItemGroup>
     <MakeDir Directories="$(OutDir)\PythonHome" />
-    <Copy SourceFiles="@(PythonLibFiles)" DestinationFolder="$(OutDir)\PythonHome\Lib\%(RecursiveDir)" SkipUnchangedFiles="true"/>
-
+    <Copy SourceFiles="@(PythonLibFiles)" DestinationFolder="$(OutDir)\PythonHome\Lib\%(RecursiveDir)" SkipUnchangedFiles="true" />
     <MakeDir Directories="$(OutDir)\PythonHome\Include" />
-    <Copy SourceFiles="..\..\..\PC\pyconfig.h" DestinationFolder="$(OutDir)\PythonHome\Include" SkipUnchangedFiles="true"/>
-
+    <Copy SourceFiles="..\..\..\PC\pyconfig.h" DestinationFolder="$(OutDir)\PythonHome\Include" SkipUnchangedFiles="true" />
     <!-- WinRT extension -->
     <ItemGroup>
       <WinRTExtensionFiles Include="$(WinRTExtensionRootFolder)\**" />
     </ItemGroup>
-
-    <Copy SourceFiles="@(WinRTExtensionFiles)" DestinationFolder="$(OutDir)\PythonHome\WinRTExtension\%(RecursiveDir)" SkipUnchangedFiles="true"/>
-
+    <Copy SourceFiles="@(WinRTExtensionFiles)" DestinationFolder="$(OutDir)\PythonHome\WinRTExtension\%(RecursiveDir)" SkipUnchangedFiles="true" />
     <ItemGroup>
-        <None Include="$(OutDir)\PythonHome\**">
-          <RootFolder>$(OutDir)</RootFolder>
-          <DeploymentContent>true</DeploymentContent>
-          <Visible>false</Visible>
-        </None>
+      <None Include="$(OutDir)\PythonHome\**">
+        <RootFolder>$(OutDir)</RootFolder>
+        <DeploymentContent>true</DeploymentContent>
+        <Visible>false</Visible>
+      </None>
     </ItemGroup>
   </Target>
   <Target Name="BuildLibs" DependsOnTargets="CopyLibs" BeforeTargets="ClCompile">

--- a/cpython/Tools/pyuwp/pyuwpbackgroundservice/pyuwpbackgroundservice.vcxproj
+++ b/cpython/Tools/pyuwp/pyuwpbackgroundservice/pyuwpbackgroundservice.vcxproj
@@ -48,35 +48,35 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/cpython/Tools/pyuwp/pyuwpsdk/pyuwpsdk.csproj
+++ b/cpython/Tools/pyuwp/pyuwpsdk/pyuwpsdk.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>pyuwpsdk</RootNamespace>
     <AssemblyName>pyuwpsdk</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/cpython/Tools/pyuwp/pyuwpsdk/source.extension.vsixmanifest
+++ b/cpython/Tools/pyuwp/pyuwpsdk/source.extension.vsixmanifest
@@ -13,4 +13,11 @@
   <Assets>
     <Asset Type="Microsoft.ExtensionSDK" d:Source="File" Path="SDKManifest.xml" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.ComponentGroup.UWP.VC" Version="[15.0.25904.2,16.0)" DisplayName="C++ UWP support" />
+    <Prerequisite Id="Microsoft.Component.VC.Runtime.OSSupport" Version="[15.0.25904.2,16.0)" DisplayName="Visual C++ runtime for UWP" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.Windows10SDK.14393" Version="[15.0.25904.2,16.0)" DisplayName="Windows 10 SDK (10.0.14393.0)" />
+    <Prerequisite Id="Microsoft.PythonTools.UWP" Version="[15.0.25904.2,16.0)" DisplayName="Python IoT support" />
+    <Prerequisite Id="Microsoft.PythonTools" Version="[15.0.25904.2,16.0)" DisplayName="Python language support" />
+  </Prerequisites>
 </PackageManifest>

--- a/extensions/winrt/_app_service/_app_service.vcxproj
+++ b/extensions/winrt/_app_service/_app_service.vcxproj
@@ -45,35 +45,35 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/extensions/winrt/_app_service/_app_service.vcxproj
+++ b/extensions/winrt/_app_service/_app_service.vcxproj
@@ -35,9 +35,9 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
     <PythonDir>..\..\..\cpython</PythonDir>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
   <Import Project="$(PythonDir)\PCBuild\python.props" />

--- a/extensions/winrt/_winrt/_winrt.vcxproj
+++ b/extensions/winrt/_winrt/_winrt.vcxproj
@@ -45,35 +45,35 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/extensions/winrt/_winrt/_winrt.vcxproj
+++ b/extensions/winrt/_winrt/_winrt.vcxproj
@@ -35,9 +35,9 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
     <PythonDir>..\..\..\cpython</PythonDir>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
   <Import Project="$(PythonDir)\PCBuild\python.props" />


### PR DESCRIPTION
- Update WinSDK version to 10.0.14393.0 
- Update PlatfromToolset from v140 to v141
- msbuild.exe now treats multi-line string differently.  Added %0A to
  denote line breaks
- Added prerequisites to pyuwpsdk's vsixmanifest